### PR TITLE
chore: migrate to @sideby-me/rtc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Needed so the GITHUB_TOKEN can read the private @sideby-me/* packages
-    # (media-sdk + media-sdk-types) from GitHub Packages during `npm ci`.
+    # (@sideby-me/rtc) from GitHub Packages during `npm ci`.
     permissions:
       contents: read
       packages: read

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@radix-ui/react-slider": "^1.3.6",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-switch": "^1.2.6",
-        "@sideby-me/media-sdk": "^0.2.2",
+        "@sideby-me/rtc": "^0.9.0",
         "@types/hls.js": "^0.13.3",
         "@types/node": "^20",
         "autoprefixer": "^10.4.21",
@@ -2498,12 +2498,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@sideby-me/media-sdk": {
-      "version": "0.2.2",
-      "resolved": "https://npm.pkg.github.com/download/@sideby-me/media-sdk/0.2.2/e189adaa421fb636dc8843012200d42a6e764890",
-      "integrity": "sha512-Hfq1K8ux/fak4P3GMHgGUvdOUphsfuOW1oPdY6ZOstIdaQJgT0jRHj33DO61kMcqR8oXKynXHQrqaSBA7o/3Yg==",
+    "node_modules/@sideby-me/rtc": {
+      "version": "0.9.0",
+      "resolved": "https://npm.pkg.github.com/download/@sideby-me/rtc/0.9.0/6387a96beea752e54c0f9eb7dcb5734ba724ef7a",
+      "integrity": "sha512-FL6M+orkyJj3/MIvcdyzrN//A/WoupZHpOq5CUoYmr3zrKMsctnNv/21WTZ23wWSalSB8ZyxC+uQJvMWlVlP2g==",
       "dependencies": {
-        "@sideby-me/media-sdk-types": "^0.1.0",
+        "@sideby-me/rtc-types": "^0.9.0",
         "mediasoup-client": "3.20.0",
         "ws": "8.21.0"
       },
@@ -2511,15 +2511,15 @@
         "react": ">=18"
       }
     },
-    "node_modules/@sideby-me/media-sdk-types": {
-      "version": "0.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@sideby-me/media-sdk-types/0.1.0/964cf35ed0691b9aac32596b0112e9d1ce7227db",
-      "integrity": "sha512-PD2UaLjooabrmUqq3khEBgqVBVEKXdmwvxnRZN5kVimDvi9A8xDXbk3cII+jf5BOffmY3xRUNyIq5IXpnn3RpA==",
+    "node_modules/@sideby-me/rtc-types": {
+      "version": "0.9.0",
+      "resolved": "https://npm.pkg.github.com/download/@sideby-me/rtc-types/0.9.0/22df17f9e321ee1dc4e128056d7f419da3451630",
+      "integrity": "sha512-WZQTEczo91388VpGJBxOWjxkRlVZ2KiYdNaocozC2fLP7tWs2bnri1c75osyaIhwlRiROAQGj206wWJtEJN7VQ==",
       "dependencies": {
         "zod": "^4.0"
       }
     },
-    "node_modules/@sideby-me/media-sdk/node_modules/ws": {
+    "node_modules/@sideby-me/rtc/node_modules/ws": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
       "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-switch": "^1.2.6",
-    "@sideby-me/media-sdk": "^0.2.2",
+    "@sideby-me/rtc": "^0.9.0",
     "@types/hls.js": "^0.13.3",
     "@types/node": "^20",
     "autoprefixer": "^10.4.21",

--- a/src/features/media/use-media.ts
+++ b/src/features/media/use-media.ts
@@ -4,11 +4,11 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSocket } from '@/src/core/socket';
 import { logDebug } from '@/src/core/logger';
 import { toast } from 'sonner';
-import { useMediaRoom } from '@sideby-me/media-sdk/react';
-import type { MediaTokenResponse, SfuSession } from '@sideby-me/media-sdk';
+import { useMediaRoom } from '@sideby-me/rtc/react';
+import type { MediaTokenResponse, SfuSession } from '@sideby-me/rtc';
 
 // ── SDK version shim ───────────────────────────────────────────────────────────
-// getSnapshot() is available in media-sdk ≥0.2.0. This local type allows the
+// getSnapshot() is available in @sideby-me/rtc (media-sdk ≥0.2.0-era). This local type allows the
 // duck-type guard in the session effect to compile without requiring the new
 // package version to be installed. Remove once watch requires ≥0.2.0.
 type SfuSessionWithSnapshot = SfuSession & {
@@ -332,7 +332,7 @@ export function useMedia({ roomId }: UseMediaProps): UseMediaReturn {
     // are emitted before this useEffect runs (handlers not yet registered). Hydrate state
     // from the session snapshot immediately after registration so existing participants
     // are visible on B's first render, not just after the next reconnect.
-    // Runtime guard: getSnapshot() is available in media-sdk ≥0.2.0. The duck-type
+    // Runtime guard: getSnapshot() is available in @sideby-me/rtc (media-sdk ≥0.2.0-era). The duck-type
     // check allows the same watch build to work against both old and new SDK versions
     // while the republish + reinstall is in flight.
     if (typeof (session as { getSnapshot?: unknown }).getSnapshot === 'function') {


### PR DESCRIPTION
Companion to the SDK rename (`media-sdk` → `rtc.sideby.me`).

- dep `@sideby-me/media-sdk@^0.2.2` → `@sideby-me/rtc@^0.9.0`
- imports in `src/features/media/use-media.ts`: `@sideby-me/rtc` + `@sideby-me/rtc/react`
- stale package-name comments refreshed

Full `next build` (ESLint + typecheck) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)