### PR TITLE
chore(env): standardize .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,23 @@
-NODE_ENV=development
-DEPLOYMENT_ENVIRONMENT=development
+# ==============================================================
+#  watch.sideby.me — environment (Next.js 15, frontend-only)
+#  Tags: [req] required in prod · [shared:X] must match service X
+#  NEXT_PUBLIC_* are inlined at BUILD time — changing them needs a
+#  rebuild, not just a redeploy, and they can never hold secrets.
+#  SECRETS below carry placeholders only — never commit real values.
+# ==============================================================
 
-# Socket.IO backend
-NEXT_PUBLIC_SYNC_URL=http://localhost:3001
-
-# Video proxy URL
-NEXT_PUBLIC_VIDEO_PROXY_URL=http://localhost:8787
-
-# TURN for production
-NEXT_PUBLIC_METERED_API_KEY=
-
-# OpenSubtitles API
+# ===== SECRETS (never commit real values) =====
+# Server-only (app/api/subtitles/**); optional — subtitle search fails without it.
 OPENSUBTITLES_API_KEY=
+
+# ===== CONFIG (same across environments) =====
+NODE_ENV=development
+# Feature flags (src/lib/feature-flags.ts) — override the code defaults.
+NEXT_PUBLIC_FF_SUBTITLES_SUPPORT=true
+NEXT_PUBLIC_FF_SFU_MEDIA=false
+
+# ===== ENVIRONMENT-SPECIFIC (differs staging vs prod; build-time inlined) =====
+# Socket.IO + REST base URL for the sync backend.
+NEXT_PUBLIC_SYNC_URL=http://localhost:3001          # [req] prod: https://sync.sideby.me
+# pipe video-proxy / Lens playback base URL. Unset = play direct.
+NEXT_PUBLIC_VIDEO_PROXY_URL=http://localhost:8787   # prod: https://pipe.sideby.me


### PR DESCRIPTION
Rewrites `.env.example` into the three-section layout. Removes dead `NEXT_PUBLIC_METERED_API_KEY` (self-hosted coturn replaced Metered) and unused `DEPLOYMENT_ENVIRONMENT`; documents the `NEXT_PUBLIC_FF_*` flags and the build-time inlining caveat.

Part of WHAT-72 — standardize environment configuration across all services. Adopts the shared house style: **SECRETS** (placeholders only) / **CONFIG** (same everywhere) / **ENVIRONMENT-SPECIFIC** (differs staging↔prod), with `[req]` and `[shared:X]` tags.