### PR TITLE
ci: gate staging with build & lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - staging
   pull_request:
     branches:
       - main
+      - staging
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Adds `staging` to the CI `push`/`pull_request` branch filters so the feat → PR → staging flow runs Build & Lint on staging. Previously CI only ran on main.