### PR TITLE
chore: ignore local .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ next-env.d.ts
 # etc
 .github/**/*.md
 notepad/
+.env
+.env*.local


### PR DESCRIPTION
Precise `.env` / `.env*.local` ignore (keeps `.env.example` tracked).