### PR TITLE
docs: note staging backend URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,6 @@ NEXT_PUBLIC_FF_SFU_MEDIA=false
 
 # ===== ENVIRONMENT-SPECIFIC (differs staging vs prod; build-time inlined) =====
 # Socket.IO + REST base URL for the sync backend.
-NEXT_PUBLIC_SYNC_URL=http://localhost:3001          # [req] prod: https://sync.sideby.me
+NEXT_PUBLIC_SYNC_URL=http://localhost:3001          # [req] prod: https://sync.sideby.me · staging: https://sync-staging.sideby.me
 # pipe video-proxy / Lens playback base URL. Unset = play direct.
-NEXT_PUBLIC_VIDEO_PROXY_URL=http://localhost:8787   # prod: https://pipe.sideby.me
+NEXT_PUBLIC_VIDEO_PROXY_URL=http://localhost:8787   # prod: https://pipe.sideby.me · staging: https://pipe-staging.sideby.me


### PR DESCRIPTION
Documents the staging sync/pipe hostnames alongside the prod ones in `.env.example`.