### PR TITLE
chore: promote staging to main (env docs + gitignore)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,6 @@ NEXT_PUBLIC_FF_SFU_MEDIA=false
 
 # ===== ENVIRONMENT-SPECIFIC (differs staging vs prod; build-time inlined) =====
 # Socket.IO + REST base URL for the sync backend.
-NEXT_PUBLIC_SYNC_URL=http://localhost:3001          # [req] prod: https://sync.sideby.me
+NEXT_PUBLIC_SYNC_URL=http://localhost:3001          # [req] prod: https://sync.sideby.me · staging: https://sync-staging.sideby.me
 # pipe video-proxy / Lens playback base URL. Unset = play direct.
-NEXT_PUBLIC_VIDEO_PROXY_URL=http://localhost:8787   # prod: https://pipe.sideby.me
+NEXT_PUBLIC_VIDEO_PROXY_URL=http://localhost:8787   # prod: https://pipe.sideby.me · staging: https://pipe-staging.sideby.me

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ next-env.d.ts
 # etc
 .github/**/*.md
 notepad/
+.env
+.env*.local


### PR DESCRIPTION
Aligns `main` with `staging`. No runtime code changes.

- docs: note staging backend URLs in `.env.example` (#38)
- chore: ignore local `.env` files, keep `.env.example` tracked (#37)

Merging triggers a Vercel production rebuild of an otherwise identical app.