### PR TITLE
ci: gate Vercel deploys behind CI passing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,5 +50,8 @@ jobs:
       - name: Lint Code
         run: npm run lint
 
+      - name: Run Tests
+        run: npm run test
+
       - name: Build Project
         run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+    branches: [main, staging]
+
+concurrency:
+  group: deploy-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel@latest
+
+      - name: Pull Vercel env (production)
+        if: ${{ github.event.workflow_run.head_branch == 'main' }}
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build (production)
+        if: ${{ github.event.workflow_run.head_branch == 'main' }}
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy (production)
+        if: ${{ github.event.workflow_run.head_branch == 'main' }}
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Pull Vercel env (preview)
+        if: ${{ github.event.workflow_run.head_branch != 'main' }}
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build (preview)
+        if: ${{ github.event.workflow_run.head_branch != 'main' }}
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy (preview)
+        if: ${{ github.event.workflow_run.head_branch != 'main' }}
+        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "main": false,
+      "staging": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a `Run Tests` step to `ci.yml` (`npm run test`) — CI previously only ran format-check, lint, and build
- Add `vercel.json` disabling Vercel's automatic Git-triggered deploy for direct pushes to `main`/`staging` only (feature-branch PR previews are unaffected)
- Add `deploy.yml`, triggered by CI's completion (`workflow_run`), that deploys via the Vercel CLI only after CI passes — `main` → production, `staging` → preview, checkout pinned to the exact commit CI validated

## Required follow-up
`VERCEL_TOKEN` needs to be added as a repo secret (Vercel → Account Settings → Tokens) before `deploy.yml` can actually deploy — `VERCEL_ORG_ID`/`VERCEL_PROJECT_ID` are already set. Until then this workflow will fail at the Vercel CLI step, which is expected.

## Test plan
- [x] `npm run test` exits 0 (88 tests)
- [x] `vercel.json`, `ci.yml`, `deploy.yml` are valid
- [ ] Live deploy via `deploy.yml` — blocked on `VERCEL_TOKEN`