### PR TITLE
ci: fix Vercel deploy never firing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,18 @@ jobs:
 
       - name: Build Project
         run: npm run build
+
+  # Runs only on a direct push to main/staging, after the checks above pass.
+  # Calling deploy.yml directly (workflow_call) instead of the old
+  # workflow_run trigger avoids a GitHub Actions requirement that the callee's
+  # workflow_run trigger exist on the DEFAULT branch (main) before it will
+  # ever fire — that silently broke this gate on staging entirely.
+  deploy:
+    name: Deploy
+    needs: build_and_lint
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/deploy.yml
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,18 +1,14 @@
 name: Deploy
 
 on:
-  workflow_run:
-    workflows: ['CI']
-    types: [completed]
-    branches: [main, staging]
+  workflow_call:
 
 concurrency:
-  group: deploy-${{ github.event.workflow_run.head_branch }}
+  group: deploy-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -22,32 +18,30 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
 
       - name: Pull Vercel env (production)
-        if: ${{ github.event.workflow_run.head_branch == 'main' }}
+        if: ${{ github.ref_name == 'main' }}
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build (production)
-        if: ${{ github.event.workflow_run.head_branch == 'main' }}
+        if: ${{ github.ref_name == 'main' }}
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy (production)
-        if: ${{ github.event.workflow_run.head_branch == 'main' }}
+        if: ${{ github.ref_name == 'main' }}
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Pull Vercel env (preview)
-        if: ${{ github.event.workflow_run.head_branch != 'main' }}
+        if: ${{ github.ref_name != 'main' }}
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build (preview)
-        if: ${{ github.event.workflow_run.head_branch != 'main' }}
+        if: ${{ github.ref_name != 'main' }}
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy (preview)
-        if: ${{ github.event.workflow_run.head_branch != 'main' }}
+        if: ${{ github.ref_name != 'main' }}
         run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary
`deploy.yml`'s `workflow_run` trigger never fires: GitHub requires the workflow file containing that trigger to exist on the repo's default branch (`main`) — it only landed on `staging`, so it was inert there. Combined with Vercel's own auto-deploy already being disabled by `vercel.json` (which does apply immediately, since it's read at the deployed commit), staging pushes were getting **no deployment at all**.

## Fix
Replace `workflow_run` with `workflow_call`, invoked directly from a new job in `ci.yml` gated on the build/lint/test job passing, for pushes to either `main` or `staging`. Runs in the same triggering event — no default-branch dependency. Swapped `github.event.workflow_run.head_branch`/`head_sha` for `github.ref_name`/default checkout, which resolve correctly in a called workflow.

## Test plan
- [x] YAML valid
- [ ] Merge and confirm a staging push actually triggers a Vercel preview deploy