### PR TITLE
ci: add NODE_AUTH_TOKEN to the Vercel deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,10 @@ jobs:
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      # .npmrc reads ${NODE_AUTH_TOKEN} for npm.pkg.github.com — `vercel build`
+      # runs `npm install` internally, which needs this to resolve the private
+      # @sideby-me/rtc package from GitHub Packages, same as ci.yml's own install step.
+      NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
First real run of deploy.yml (after PR #42's concurrency fix) failed: `vercel build` runs `npm install` internally to resolve `@sideby-me/rtc` from GitHub Packages, but the job never set `NODE_AUTH_TOKEN`, so it hit `npm error 401 Unauthorized`.

## Fix
Add `NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN || secrets.GITHUB_TOKEN }}` to the job's env, matching `ci.yml`'s own install step.

## Test plan
- [x] YAML valid
- [ ] Merge and confirm a staging push completes a full Vercel deploy