### PR TITLE
Promote staging to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,5 +50,8 @@ jobs:
       - name: Lint Code
         run: npm run lint
 
+      - name: Run Tests
+        run: npm run test
+
       - name: Build Project
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,6 @@ on:
       - main
       - staging
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build_and_lint:
     name: Build & Lint
@@ -24,6 +20,16 @@ jobs:
     permissions:
       contents: read
       packages: read
+
+    # Job-level (not workflow-level) concurrency: a workflow-level `concurrency:`
+    # block silently breaks any job in this same workflow that calls a reusable
+    # workflow via `uses:` (confirmed empirically — the called job never gets
+    # scheduled and the whole run reports failure, with no useful error). Scoping
+    # it to just this job keeps the "cancel superseded lint/test runs" behavior
+    # without touching the deploy job below.
+    concurrency:
+      group: ${{ github.workflow }}-lint-${{ github.ref }}
+      cancel-in-progress: true
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,18 @@ jobs:
 
       - name: Build Project
         run: npm run build
+
+  # Runs only on a direct push to main/staging, after the checks above pass.
+  # Calling deploy.yml directly (workflow_call) instead of the old
+  # workflow_run trigger avoids a GitHub Actions requirement that the callee's
+  # workflow_run trigger exist on the DEFAULT branch (main) before it will
+  # ever fire — that silently broke this gate on staging entirely.
+  deploy:
+    name: Deploy
+    needs: build_and_lint
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/deploy.yml
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,10 @@ jobs:
     env:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      # .npmrc reads ${NODE_AUTH_TOKEN} for npm.pkg.github.com — `vercel build`
+      # runs `npm install` internally, which needs this to resolve the private
+      # @sideby-me/rtc package from GitHub Packages, same as ci.yml's own install step.
+      NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,18 +1,14 @@
 name: Deploy
 
 on:
-  workflow_run:
-    workflows: ['CI']
-    types: [completed]
-    branches: [main, staging]
+  workflow_call:
 
 concurrency:
-  group: deploy-${{ github.event.workflow_run.head_branch }}
+  group: deploy-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -22,32 +18,30 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
 
       - name: Pull Vercel env (production)
-        if: ${{ github.event.workflow_run.head_branch == 'main' }}
+        if: ${{ github.ref_name == 'main' }}
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build (production)
-        if: ${{ github.event.workflow_run.head_branch == 'main' }}
+        if: ${{ github.ref_name == 'main' }}
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy (production)
-        if: ${{ github.event.workflow_run.head_branch == 'main' }}
+        if: ${{ github.ref_name == 'main' }}
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Pull Vercel env (preview)
-        if: ${{ github.event.workflow_run.head_branch != 'main' }}
+        if: ${{ github.ref_name != 'main' }}
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build (preview)
-        if: ${{ github.event.workflow_run.head_branch != 'main' }}
+        if: ${{ github.ref_name != 'main' }}
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy (preview)
-        if: ${{ github.event.workflow_run.head_branch != 'main' }}
+        if: ${{ github.ref_name != 'main' }}
         run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+    branches: [main, staging]
+
+concurrency:
+  group: deploy-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel@latest
+
+      - name: Pull Vercel env (production)
+        if: ${{ github.event.workflow_run.head_branch == 'main' }}
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build (production)
+        if: ${{ github.event.workflow_run.head_branch == 'main' }}
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy (production)
+        if: ${{ github.event.workflow_run.head_branch == 'main' }}
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Pull Vercel env (preview)
+        if: ${{ github.event.workflow_run.head_branch != 'main' }}
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build (preview)
+        if: ${{ github.event.workflow_run.head_branch != 'main' }}
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy (preview)
+        if: ${{ github.event.workflow_run.head_branch != 'main' }}
+        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "main": false,
+      "staging": false
+    }
+  }
+}


### PR DESCRIPTION
Routine staging -> main sync. Note: this will trigger an automatic production deploy via the new CI-gated deploy.yml (workflow_call) chain — first real exercise of the main/production path. Change is CI/tooling-only (test step, vercel.json, deploy.yml), no runtime behavior change.