### PR TITLE
fix(video-sync): stop a rebuffering host from rewinding the whole room

### DIFF
--- a/src/features/video-sync/hooks/use-video-sync.ts
+++ b/src/features/video-sync/hooks/use-video-sync.ts
@@ -299,9 +299,8 @@ export function useVideoSync({
       // Never re-anchor off a stalled host. `paused` stays false while a video rebuffers, so a
       // stalling host would otherwise publish a frozen currentTime as authoritative — which the
       // server rebroadcasts and every healthy viewer then hard-seeks backward to match.
-      const readyState = (
-        player as { getVideoElement?: () => HTMLVideoElement | null }
-      ).getVideoElement?.()?.readyState;
+      const readyState = (player as { getVideoElement?: () => HTMLVideoElement | null }).getVideoElement?.()
+        ?.readyState;
 
       if (!shouldEmitReanchor({ isPlaying, isBuffering, readyState })) {
         logDebug('video', 'sync_check_skip_stalled', 'Skipping host re-anchor - local player is stalled', {

--- a/src/features/video-sync/hooks/use-video-sync.ts
+++ b/src/features/video-sync/hooks/use-video-sync.ts
@@ -7,7 +7,12 @@ import { HLSPlayerRef } from '@/src/core/video/hls-player';
 import { CastPlayerRef } from '@/src/features/media/cast';
 import { calculateCurrentTime } from '@/src/lib/video-utils';
 import { SYNC_COOLDOWN_MS, HOST_REANCHOR_MS, SYNC_CORRECTOR_INTERVAL_MS } from '@/src/lib/constants';
-import { decideCorrection, shouldApplySyncUpdate, type CorrectorMode } from '@/src/features/video-sync/lib/corrector';
+import {
+  decideCorrection,
+  shouldApplySyncUpdate,
+  shouldEmitReanchor,
+  type CorrectorMode,
+} from '@/src/features/video-sync/lib/corrector';
 import { Room, User } from '@/types';
 import { logDebug } from '@/src/core/logger';
 
@@ -280,12 +285,31 @@ export function useVideoSync({
       const currentTime = player.getCurrentTime();
 
       let isPlaying: boolean;
+      let isBuffering = false;
       if ('getPlayerState' in player) {
-        isPlaying = player.getPlayerState() === YT_STATES.PLAYING;
+        const ytState = player.getPlayerState();
+        isPlaying = ytState === YT_STATES.PLAYING;
+        isBuffering = ytState === YT_STATES.BUFFERING;
       } else if ('isPaused' in player) {
         isPlaying = !player.isPaused();
       } else {
         isPlaying = false;
+      }
+
+      // Never re-anchor off a stalled host. `paused` stays false while a video rebuffers, so a
+      // stalling host would otherwise publish a frozen currentTime as authoritative — which the
+      // server rebroadcasts and every healthy viewer then hard-seeks backward to match.
+      const readyState = (
+        player as { getVideoElement?: () => HTMLVideoElement | null }
+      ).getVideoElement?.()?.readyState;
+
+      if (!shouldEmitReanchor({ isPlaying, isBuffering, readyState })) {
+        logDebug('video', 'sync_check_skip_stalled', 'Skipping host re-anchor - local player is stalled', {
+          currentTime,
+          readyState,
+          isBuffering,
+        });
+        return;
       }
 
       logDebug('video', 'sync_check', `Host re-anchor: ${currentTime.toFixed(2)}s, playing: ${isPlaying}`);

--- a/src/features/video-sync/lib/corrector.ts
+++ b/src/features/video-sync/lib/corrector.ts
@@ -69,3 +69,43 @@ export function decideCorrection(params: DecideCorrectionParams): CorrectionResu
 export function shouldApplySyncUpdate(anchorTimestamp: number, lastIntentTimestamp: number): boolean {
   return anchorTimestamp >= lastIntentTimestamp;
 }
+
+/** HTMLMediaElement.readyState — below HAVE_FUTURE_DATA the element cannot advance currentTime. */
+export const MEDIA_HAVE_FUTURE_DATA = 3;
+
+export interface ReanchorGateInput {
+  /** Whether the host's player reports it is not paused. */
+  isPlaying: boolean;
+  /** Player explicitly reports a stall (e.g. the YouTube BUFFERING state). */
+  isBuffering?: boolean;
+  /** HTMLMediaElement.readyState, when the active player exposes a video element. */
+  readyState?: number;
+}
+
+/**
+ * Stalled-host guard for the periodic host re-anchor.
+ *
+ * `HTMLMediaElement.paused` stays FALSE while a video rebuffers — it only flips on an explicit
+ * pause() or at end of media. So a rebuffering host reports `isPlaying: true` with a frozen
+ * currentTime, and re-anchoring that to the server overwrites the authoritative timeline with a
+ * stalled one. The server then rebroadcasts it to the room and every healthy viewer, seeing a
+ * large negative drift, hard-seeks BACKWARD to the stalled host's position — turning one
+ * person's rebuffer into a room-wide rewind, repeated every re-anchor until the host recovers.
+ *
+ * A stalled host is therefore not an authoritative position and must not re-anchor. A *paused*
+ * host still is: its currentTime is stable and meaningful.
+ */
+export function shouldEmitReanchor(input: ReanchorGateInput): boolean {
+  const { isPlaying, isBuffering, readyState } = input;
+
+  // A paused host is a stable, legitimate anchor.
+  if (!isPlaying) return true;
+
+  if (isBuffering) return false;
+
+  // Below HAVE_FUTURE_DATA the element has no data to play past the current frame — it is
+  // stalled, so its currentTime is frozen and must not be published as authoritative.
+  if (readyState !== undefined && readyState < MEDIA_HAVE_FUTURE_DATA) return false;
+
+  return true;
+}

--- a/tests/video-sync/corrector.test.ts
+++ b/tests/video-sync/corrector.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { decideCorrection, shouldApplySyncUpdate } from '@/src/features/video-sync/lib/corrector';
+import {
+  decideCorrection,
+  shouldApplySyncUpdate,
+  shouldEmitReanchor,
+  MEDIA_HAVE_FUTURE_DATA,
+} from '@/src/features/video-sync/lib/corrector';
 import { SYNC_DEAD_BAND_S, SYNC_SOFT_BAND_S, SYNC_MAX_NUDGE, YOUTUBE_SEEK_TOLERANCE_S } from '@/src/lib/constants';
 
 describe('decideCorrection — mode: rate (HTML5/HLS)', () => {
@@ -139,5 +144,36 @@ describe('shouldApplySyncUpdate', () => {
 
   it('keeps anchors at equal timestamps', () => {
     expect(shouldApplySyncUpdate(2000, 2000)).toBe(true);
+  });
+});
+
+describe('shouldEmitReanchor — stalled-host guard', () => {
+  it('emits for a healthy playing host', () => {
+    expect(shouldEmitReanchor({ isPlaying: true, readyState: 4 })).toBe(true);
+  });
+
+  it('emits at exactly HAVE_FUTURE_DATA (boundary, not stalled)', () => {
+    expect(shouldEmitReanchor({ isPlaying: true, readyState: MEDIA_HAVE_FUTURE_DATA })).toBe(true);
+  });
+
+  it('suppresses one step below HAVE_FUTURE_DATA (boundary, stalled)', () => {
+    expect(shouldEmitReanchor({ isPlaying: true, readyState: MEDIA_HAVE_FUTURE_DATA - 1 })).toBe(false);
+  });
+
+  it('suppresses at HAVE_NOTHING', () => {
+    expect(shouldEmitReanchor({ isPlaying: true, readyState: 0 })).toBe(false);
+  });
+
+  it('suppresses when the player reports buffering, whatever the readyState', () => {
+    expect(shouldEmitReanchor({ isPlaying: true, isBuffering: true, readyState: 4 })).toBe(false);
+  });
+
+  it('emits for a PAUSED host even when its buffer is empty (a paused position is stable)', () => {
+    expect(shouldEmitReanchor({ isPlaying: false, readyState: 0 })).toBe(true);
+    expect(shouldEmitReanchor({ isPlaying: false, isBuffering: true })).toBe(true);
+  });
+
+  it('emits when readyState is unavailable and nothing reports a stall', () => {
+    expect(shouldEmitReanchor({ isPlaying: true })).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

When any one person in a room rebuffers, the whole room gets dragged — guests are hard-seeked backward, repeatedly, then forward again on recovery. One viewer's bad network ruins playback for everyone.

## Cause

`HTMLMediaElement.paused` stays `false` during a rebuffer. The element is stalled, not paused — but `use-video-sync.ts:286` only checked `!player.isPaused()`.

So a stalled **host** computed `isPlaying: true` with a **frozen** `currentTime` and re-anchored it every 10 s. `sync` persisted that verbatim and its ticker rebroadcast it every 2 s, driving every healthy guest past `SYNC_SOFT_BAND_S = 1.0` into `corrector.ts:61`'s `{ action: 'seek' }` — backward, on a loop, for as long as the host was buffering.

Guest stalls were always harmless: every emit path is `isHost`-gated. Only the host could do this.

This is independent of proxy latency. Reducing how often stalls happen only makes the amplifier fire less often; it does not disarm it.

## Changes

- New pure `shouldEmitReanchor()` in `src/features/video-sync/lib/corrector.ts` — node-testable, matching the existing `corrector.ts` / `hls-error-policy.ts` house style.
- Wired into `startSyncCheck`: the host does **not** re-anchor while its own player is stalled (`readyState < HAVE_FUTURE_DATA`, or YouTube `BUFFERING`).

A **paused** host still re-anchors — its position is stable and meaningful. Only the stalled case is suppressed.

No hls.js constant tuning: buffer config is not the cause here, and tuning it would only mask the latency rather than fix the amplification.

## Verification

- 95/95 tests pass; full `next build` green (which runs ESLint — this project's required verify step).
- `tests/video-sync/corrector.test.ts` is mutation-validated: mutating the guard to always-emit (pre-fix behaviour) fails 3 tests; restored, 24/24 pass.
- Boundary neighbours tested at exactly / one step either side of `MEDIA_HAVE_FUTURE_DATA`.

## Manual check after deploy

Throttle the **host** in a multi-person room on a Lens HLS stream. Guests should hold position instead of rewinding.

## Related

Defence in depth with `sync.sideby.me#feat/reject-stalled-host-reanchor`, which rejects a rewinding re-anchor server-side so an older or third-party client cannot rewind a room either. The underlying stall frequency is addressed separately in `pipe.sideby.me#feat/lens-path-latency`.
