### PR TITLE
ci: pull branch-scoped Preview env vars in the Vercel deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,9 +38,13 @@ jobs:
         if: ${{ github.ref_name == 'main' }}
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
 
+      # --git-branch is REQUIRED to pull branch-scoped Preview env vars. Without it, only
+      # unscoped Preview values arrive, so branch-specific NEXT_PUBLIC_* (which Next.js
+      # inlines at BUILD time) silently fall back to their in-code dev defaults — e.g.
+      # NEXT_PUBLIC_SYNC_URL degrading to http://localhost:3001 in the staging bundle.
       - name: Pull Vercel env (preview)
         if: ${{ github.ref_name != 'main' }}
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=preview --git-branch=${{ github.ref_name }} --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build (preview)
         if: ${{ github.ref_name != 'main' }}


### PR DESCRIPTION
## Problem

`https://watch-staging.sideby.me/create` cannot connect to the sync backend. The browser attempts:

```
WebSocket connection to 'ws://localhost:3001/api/socket/io/?EIO=4&transport=websocket' failed
[room:socket_error] Socket connection error
```

Every room on staging is dead — the client is dialing `localhost` instead of `sync-staging.sideby.me`.

## Cause

`vercel pull --environment=preview` returns only **unscoped** Preview values unless `--git-branch` is passed. The deploy job omitted it, so the three variables scoped to **Preview (staging)** — `NEXT_PUBLIC_SYNC_URL`, `NEXT_PUBLIC_VIDEO_PROXY_URL`, `NEXT_PUBLIC_FF_SFU_MEDIA` — were never pulled.

Because Next.js inlines `NEXT_PUBLIC_*` at **build** time, the missing value didn't fail loudly: `socket-provider.tsx:43` fell back to its in-code dev default and baked `http://localhost:3001` into the shipped bundle.

```ts
const socketUrl = process.env.NEXT_PUBLIC_SYNC_URL || 'http://localhost:3001';
```

### Evidence

- `vercel env ls` shows all three variables present and scoped `Preview (staging)` — the values are configured correctly; they were simply not being pulled.
- `vercel pull --help`: `--git-branch <NAME>  Specify the Git branch to pull specific Environment Variables for`.
- The live bundle serving `watch-staging.sideby.me` contains `localhost:3001` (in `659-*.js` and `app/layout-*.js`) and contains **no** occurrence of `sync-staging.sideby.me`.
- The deployment holding the `watch-staging.sideby.me` alias (`dpl_Aqv5UYcw9ixcKgQwN1RyHYPj4YVg`) is a **prebuilt** deploy — build step `.` at `[0ms]` — i.e. produced by this workflow's `vercel build` + `vercel deploy --prebuilt`, not by the Vercel git integration.

### Why it started

Staging env vars were added 2026-07-17. `fd3308c` (2026-07-18) introduced this Actions preview-deploy path without `--git-branch`, but it never actually fired until `91a2f64` (2026-07-19) fixed the trigger. From that point the Actions-built (env-less) deployment has been winning the `watch-staging.sideby.me` alias over the git-integration build.

## Change

Pass `--git-branch=${{ github.ref_name }}` on the preview pull, plus a comment explaining why it is load-bearing.

The production pull is deliberately untouched — Production env vars are not branch-scoped, so it needs no flag.

## Verification

`format:check` clean. The real proof is post-merge: the staging bundle must contain `sync-staging.sideby.me` and no `localhost:3001`.

```bash
curl -s https://watch-staging.sideby.me/create \
  | grep -o '/_next/static/chunks/[a-zA-Z0-9/_.-]*\.js' | sort -u \
  | while read c; do curl -s "https://watch-staging.sideby.me$c"; done \
  | grep -c 'sync-staging\.sideby\.me'
```

## Follow-up, not addressed here

Both this workflow **and** the Vercel git integration build every staging push, producing two deployments that race for the same alias. The redundancy is what let an env-less build win. Worth collapsing to one deploy path, but that is a bigger decision than this fix.
