### PR TITLE
ci: let the Vercel Git integration own staging deploys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,15 +62,24 @@ jobs:
       - name: Build Project
         run: npm run build
 
-  # Runs only on a direct push to main/staging, after the checks above pass.
+  # Runs only on a direct push to main, after the checks above pass.
   # Calling deploy.yml directly (workflow_call) instead of the old
   # workflow_run trigger avoids a GitHub Actions requirement that the callee's
   # workflow_run trigger exist on the DEFAULT branch (main) before it will
   # ever fire — that silently broke this gate on staging entirely.
+  #
+  # staging is deliberately NOT deployed from here. `vercel build --prebuilt`
+  # runs off `vercel pull`, which cannot decrypt the branch-scoped Preview
+  # NEXT_PUBLIC_* vars — it writes the literal placeholder "[SENSITIVE]", and
+  # Next.js then inlines THAT into the client bundle at build time, so the
+  # staging socket URL became the string "[SENSITIVE]". A prebuilt deploy also
+  # claims the commit SHA first, which suppressed the Vercel Git integration's
+  # own (correct) staging build entirely. Leaving preview/staging to the Git
+  # integration keeps one deploy path per environment and real env values.
   deploy:
     name: Deploy
     needs: build_and_lint
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,30 +26,14 @@ jobs:
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
 
+      # Production only. Preview/staging deploys are owned by the Vercel Git
+      # integration, NOT by this workflow — see the note above the `deploy` job in
+      # ci.yml for why.
       - name: Pull Vercel env (production)
-        if: ${{ github.ref_name == 'main' }}
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build (production)
-        if: ${{ github.ref_name == 'main' }}
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy (production)
-        if: ${{ github.ref_name == 'main' }}
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
-
-      # --git-branch is REQUIRED to pull branch-scoped Preview env vars. Without it, only
-      # unscoped Preview values arrive, so branch-specific NEXT_PUBLIC_* (which Next.js
-      # inlines at BUILD time) silently fall back to their in-code dev defaults — e.g.
-      # NEXT_PUBLIC_SYNC_URL degrading to http://localhost:3001 in the staging bundle.
-      - name: Pull Vercel env (preview)
-        if: ${{ github.ref_name != 'main' }}
-        run: vercel pull --yes --environment=preview --git-branch=${{ github.ref_name }} --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Build (preview)
-        if: ${{ github.ref_name != 'main' }}
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Deploy (preview)
-        if: ${{ github.ref_name != 'main' }}
-        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Problem

`watch-staging.sideby.me` could not connect to sync. The client was opening a socket to a URL that was not a URL:

```js
(0,n.io)("[SENSITIVE]",{path:"/api/socket/io",transports:["websocket"],...})
```

That string is really in the shipped bundle — verified byte-exact against the server's `Content-Length` (29147 bytes served, 29147 on disk, 11-character value), not an artifact of masked output.

## Cause

`[SENSITIVE]` is the placeholder the Vercel CLI writes for env vars it cannot decrypt. The three branch-scoped `Preview (staging)` variables (added 11 days ago) are marked Sensitive, so:

1. `vercel pull` writes `NEXT_PUBLIC_SYNC_URL="[SENSITIVE]"`.
2. `vercel build --prebuilt` inlines that literal into the client bundle, because Next.js resolves `NEXT_PUBLIC_*` at **build** time.
3. The socket provider's `process.env.NEXT_PUBLIC_SYNC_URL || 'http://localhost:3001'` fallback never fires — the placeholder is truthy.

A prebuilt deploy also claims the commit SHA before the Vercel Git integration can, and Vercel will not create a second deployment for a commit that already has one. The 10s prebuilt deploy consistently beat the ~50s platform build, so **`staging` has had no platform build since the Actions preview path began firing.**

## Evidence

Same branch, two build paths:

| Build path | Duration | `NEXT_PUBLIC_SYNC_URL` in bundle |
|---|---|---|
| Vercel Git integration (platform) | 55s | `https://sync-staging.sideby.me` |
| Actions `vercel build --prebuilt` | 10s | `[SENSITIVE]` |

- Both platform builds of `staging` from 11 days ago carry the correct host (2 occurrences each).
- Every `feat/*` branch still gets a correct 50–53s platform build, so the Git integration is active and healthy.
- `watch-staging.sideby.me` is branch-linked (the deployment also holds `watchsidebyme-git-staging-sideby-me-org.vercel.app`), so platform builds pick up the alias automatically.

## Change

- `deploy.yml` — remove the three preview steps; the workflow is production-only.
- `ci.yml` — gate the `deploy` job to `refs/heads/main`.

## Production is not affected

Production keeps the prebuilt path. Its env vars are 91 days old and decrypt normally, and the live production bundle carries the correct 22-character `https://sync.sideby.me` with zero placeholder occurrences.

## Verification after merge

A push to `staging` should now produce one ~50s platform build. Then:

```bash
curl -s https://watch-staging.sideby.me/create \
  | grep -o '/_next/static/chunks/[a-zA-Z0-9/_.-]*\.js' | sort -u \
  | while read c; do curl -s "https://watch-staging.sideby.me$c"; done \
  | grep -c 'sync-staging\.sideby\.me'
```

Expect a non-zero count, and zero matches for `[SENSITIVE]`.

## Follow-up (not in this PR)

Marking `NEXT_PUBLIC_*` variables Sensitive provides no protection — Next.js inlines them into publicly downloadable client JavaScript. It only blocks our own CI from reading them. Worth un-marking them so either build path works.
