### PR TITLE
ci: re-enable Git deployments for staging

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "git": {
     "deploymentEnabled": {
       "main": false,
-      "staging": false
+      "staging": true
     }
   }
 }


### PR DESCRIPTION
Follow-up to #47, which is incomplete without this.

`vercel.json` carried `git.deploymentEnabled.staging: false`, set when the Actions workflow took over staging deploys. With the Actions preview path removed in #47, that flag leaves staging with **no** deploy path — the push of #47's merge commit produced no Vercel deployment at all, so `watch-staging.sideby.me` is still pinned to the older bundle containing the literal `[SENSITIVE]` socket URL.

This also corrects an inference in #47: the ~50s platform builds seen on feature branches were **PR-branch** builds, which `deploymentEnabled` does not block. Pushes to `staging` were not being suppressed by the prebuilt deploy claiming the commit SHA — they were disabled outright.

`main` stays `false`: production is still deployed by the Actions workflow, and its env vars decrypt correctly under the prebuilt path.

## Verification after merge

The merge commit should produce one ~50s platform build that takes the `watch-staging.sideby.me` alias, after which:

```bash
curl -s https://watch-staging.sideby.me/create \
  | grep -o '/_next/static/chunks/[a-zA-Z0-9/_.-]*\.js' | sort -u \
  | while read c; do curl -s "https://watch-staging.sideby.me$c"; done \
  | grep -c 'sync-staging\.sideby\.me'
```

Expect non-zero, with zero matches for `[SENSITIVE]` and `localhost:3001`.