### PR TITLE
Promote staging to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,15 +62,24 @@ jobs:
       - name: Build Project
         run: npm run build
 
-  # Runs only on a direct push to main/staging, after the checks above pass.
+  # Runs only on a direct push to main, after the checks above pass.
   # Calling deploy.yml directly (workflow_call) instead of the old
   # workflow_run trigger avoids a GitHub Actions requirement that the callee's
   # workflow_run trigger exist on the DEFAULT branch (main) before it will
   # ever fire — that silently broke this gate on staging entirely.
+  #
+  # staging is deliberately NOT deployed from here. `vercel build --prebuilt`
+  # runs off `vercel pull`, which cannot decrypt the branch-scoped Preview
+  # NEXT_PUBLIC_* vars — it writes the literal placeholder "[SENSITIVE]", and
+  # Next.js then inlines THAT into the client bundle at build time, so the
+  # staging socket URL became the string "[SENSITIVE]". A prebuilt deploy also
+  # claims the commit SHA first, which suppressed the Vercel Git integration's
+  # own (correct) staging build entirely. Leaving preview/staging to the Git
+  # integration keeps one deploy path per environment and real env values.
   deploy:
     name: Deploy
     needs: build_and_lint
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,9 +38,13 @@ jobs:
         if: ${{ github.ref_name == 'main' }}
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
 
+      # --git-branch is REQUIRED to pull branch-scoped Preview env vars. Without it, only
+      # unscoped Preview values arrive, so branch-specific NEXT_PUBLIC_* (which Next.js
+      # inlines at BUILD time) silently fall back to their in-code dev defaults — e.g.
+      # NEXT_PUBLIC_SYNC_URL degrading to http://localhost:3001 in the staging bundle.
       - name: Pull Vercel env (preview)
         if: ${{ github.ref_name != 'main' }}
-        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel pull --yes --environment=preview --git-branch=${{ github.ref_name }} --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build (preview)
         if: ${{ github.ref_name != 'main' }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,30 +26,14 @@ jobs:
       - name: Install Vercel CLI
         run: npm install -g vercel@latest
 
+      # Production only. Preview/staging deploys are owned by the Vercel Git
+      # integration, NOT by this workflow — see the note above the `deploy` job in
+      # ci.yml for why.
       - name: Pull Vercel env (production)
-        if: ${{ github.ref_name == 'main' }}
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build (production)
-        if: ${{ github.ref_name == 'main' }}
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy (production)
-        if: ${{ github.ref_name == 'main' }}
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
-
-      # --git-branch is REQUIRED to pull branch-scoped Preview env vars. Without it, only
-      # unscoped Preview values arrive, so branch-specific NEXT_PUBLIC_* (which Next.js
-      # inlines at BUILD time) silently fall back to their in-code dev defaults — e.g.
-      # NEXT_PUBLIC_SYNC_URL degrading to http://localhost:3001 in the staging bundle.
-      - name: Pull Vercel env (preview)
-        if: ${{ github.ref_name != 'main' }}
-        run: vercel pull --yes --environment=preview --git-branch=${{ github.ref_name }} --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Build (preview)
-        if: ${{ github.ref_name != 'main' }}
-        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Deploy (preview)
-        if: ${{ github.ref_name != 'main' }}
-        run: vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }}

--- a/src/features/video-sync/hooks/use-video-sync.ts
+++ b/src/features/video-sync/hooks/use-video-sync.ts
@@ -299,9 +299,8 @@ export function useVideoSync({
       // Never re-anchor off a stalled host. `paused` stays false while a video rebuffers, so a
       // stalling host would otherwise publish a frozen currentTime as authoritative — which the
       // server rebroadcasts and every healthy viewer then hard-seeks backward to match.
-      const readyState = (
-        player as { getVideoElement?: () => HTMLVideoElement | null }
-      ).getVideoElement?.()?.readyState;
+      const readyState = (player as { getVideoElement?: () => HTMLVideoElement | null }).getVideoElement?.()
+        ?.readyState;
 
       if (!shouldEmitReanchor({ isPlaying, isBuffering, readyState })) {
         logDebug('video', 'sync_check_skip_stalled', 'Skipping host re-anchor - local player is stalled', {

--- a/src/features/video-sync/hooks/use-video-sync.ts
+++ b/src/features/video-sync/hooks/use-video-sync.ts
@@ -7,7 +7,12 @@ import { HLSPlayerRef } from '@/src/core/video/hls-player';
 import { CastPlayerRef } from '@/src/features/media/cast';
 import { calculateCurrentTime } from '@/src/lib/video-utils';
 import { SYNC_COOLDOWN_MS, HOST_REANCHOR_MS, SYNC_CORRECTOR_INTERVAL_MS } from '@/src/lib/constants';
-import { decideCorrection, shouldApplySyncUpdate, type CorrectorMode } from '@/src/features/video-sync/lib/corrector';
+import {
+  decideCorrection,
+  shouldApplySyncUpdate,
+  shouldEmitReanchor,
+  type CorrectorMode,
+} from '@/src/features/video-sync/lib/corrector';
 import { Room, User } from '@/types';
 import { logDebug } from '@/src/core/logger';
 
@@ -280,12 +285,31 @@ export function useVideoSync({
       const currentTime = player.getCurrentTime();
 
       let isPlaying: boolean;
+      let isBuffering = false;
       if ('getPlayerState' in player) {
-        isPlaying = player.getPlayerState() === YT_STATES.PLAYING;
+        const ytState = player.getPlayerState();
+        isPlaying = ytState === YT_STATES.PLAYING;
+        isBuffering = ytState === YT_STATES.BUFFERING;
       } else if ('isPaused' in player) {
         isPlaying = !player.isPaused();
       } else {
         isPlaying = false;
+      }
+
+      // Never re-anchor off a stalled host. `paused` stays false while a video rebuffers, so a
+      // stalling host would otherwise publish a frozen currentTime as authoritative — which the
+      // server rebroadcasts and every healthy viewer then hard-seeks backward to match.
+      const readyState = (
+        player as { getVideoElement?: () => HTMLVideoElement | null }
+      ).getVideoElement?.()?.readyState;
+
+      if (!shouldEmitReanchor({ isPlaying, isBuffering, readyState })) {
+        logDebug('video', 'sync_check_skip_stalled', 'Skipping host re-anchor - local player is stalled', {
+          currentTime,
+          readyState,
+          isBuffering,
+        });
+        return;
       }
 
       logDebug('video', 'sync_check', `Host re-anchor: ${currentTime.toFixed(2)}s, playing: ${isPlaying}`);

--- a/src/features/video-sync/lib/corrector.ts
+++ b/src/features/video-sync/lib/corrector.ts
@@ -69,3 +69,43 @@ export function decideCorrection(params: DecideCorrectionParams): CorrectionResu
 export function shouldApplySyncUpdate(anchorTimestamp: number, lastIntentTimestamp: number): boolean {
   return anchorTimestamp >= lastIntentTimestamp;
 }
+
+/** HTMLMediaElement.readyState — below HAVE_FUTURE_DATA the element cannot advance currentTime. */
+export const MEDIA_HAVE_FUTURE_DATA = 3;
+
+export interface ReanchorGateInput {
+  /** Whether the host's player reports it is not paused. */
+  isPlaying: boolean;
+  /** Player explicitly reports a stall (e.g. the YouTube BUFFERING state). */
+  isBuffering?: boolean;
+  /** HTMLMediaElement.readyState, when the active player exposes a video element. */
+  readyState?: number;
+}
+
+/**
+ * Stalled-host guard for the periodic host re-anchor.
+ *
+ * `HTMLMediaElement.paused` stays FALSE while a video rebuffers — it only flips on an explicit
+ * pause() or at end of media. So a rebuffering host reports `isPlaying: true` with a frozen
+ * currentTime, and re-anchoring that to the server overwrites the authoritative timeline with a
+ * stalled one. The server then rebroadcasts it to the room and every healthy viewer, seeing a
+ * large negative drift, hard-seeks BACKWARD to the stalled host's position — turning one
+ * person's rebuffer into a room-wide rewind, repeated every re-anchor until the host recovers.
+ *
+ * A stalled host is therefore not an authoritative position and must not re-anchor. A *paused*
+ * host still is: its currentTime is stable and meaningful.
+ */
+export function shouldEmitReanchor(input: ReanchorGateInput): boolean {
+  const { isPlaying, isBuffering, readyState } = input;
+
+  // A paused host is a stable, legitimate anchor.
+  if (!isPlaying) return true;
+
+  if (isBuffering) return false;
+
+  // Below HAVE_FUTURE_DATA the element has no data to play past the current frame — it is
+  // stalled, so its currentTime is frozen and must not be published as authoritative.
+  if (readyState !== undefined && readyState < MEDIA_HAVE_FUTURE_DATA) return false;
+
+  return true;
+}

--- a/tests/video-sync/corrector.test.ts
+++ b/tests/video-sync/corrector.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { decideCorrection, shouldApplySyncUpdate } from '@/src/features/video-sync/lib/corrector';
+import {
+  decideCorrection,
+  shouldApplySyncUpdate,
+  shouldEmitReanchor,
+  MEDIA_HAVE_FUTURE_DATA,
+} from '@/src/features/video-sync/lib/corrector';
 import { SYNC_DEAD_BAND_S, SYNC_SOFT_BAND_S, SYNC_MAX_NUDGE, YOUTUBE_SEEK_TOLERANCE_S } from '@/src/lib/constants';
 
 describe('decideCorrection — mode: rate (HTML5/HLS)', () => {
@@ -139,5 +144,36 @@ describe('shouldApplySyncUpdate', () => {
 
   it('keeps anchors at equal timestamps', () => {
     expect(shouldApplySyncUpdate(2000, 2000)).toBe(true);
+  });
+});
+
+describe('shouldEmitReanchor — stalled-host guard', () => {
+  it('emits for a healthy playing host', () => {
+    expect(shouldEmitReanchor({ isPlaying: true, readyState: 4 })).toBe(true);
+  });
+
+  it('emits at exactly HAVE_FUTURE_DATA (boundary, not stalled)', () => {
+    expect(shouldEmitReanchor({ isPlaying: true, readyState: MEDIA_HAVE_FUTURE_DATA })).toBe(true);
+  });
+
+  it('suppresses one step below HAVE_FUTURE_DATA (boundary, stalled)', () => {
+    expect(shouldEmitReanchor({ isPlaying: true, readyState: MEDIA_HAVE_FUTURE_DATA - 1 })).toBe(false);
+  });
+
+  it('suppresses at HAVE_NOTHING', () => {
+    expect(shouldEmitReanchor({ isPlaying: true, readyState: 0 })).toBe(false);
+  });
+
+  it('suppresses when the player reports buffering, whatever the readyState', () => {
+    expect(shouldEmitReanchor({ isPlaying: true, isBuffering: true, readyState: 4 })).toBe(false);
+  });
+
+  it('emits for a PAUSED host even when its buffer is empty (a paused position is stable)', () => {
+    expect(shouldEmitReanchor({ isPlaying: false, readyState: 0 })).toBe(true);
+    expect(shouldEmitReanchor({ isPlaying: false, isBuffering: true })).toBe(true);
+  });
+
+  it('emits when readyState is unavailable and nothing reports a stall', () => {
+    expect(shouldEmitReanchor({ isPlaying: true })).toBe(true);
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "git": {
     "deploymentEnabled": {
       "main": false,
-      "staging": false
+      "staging": true
     }
   }
 }


### PR DESCRIPTION
Promotes the current `staging` head to production.

## Included

**Fix — video sync**
- `fix(video-sync): stop a rebuffering host from rewinding the whole room` — a stalled host no longer re-anchors the room to its own stuck position (#45), plus corrector coverage.

**CI / deploy plumbing**
- `ci: pull branch-scoped Preview env vars in the Vercel deploy job` (#46)
- `ci: let the Vercel Git integration own staging deploys` (#47)
- `ci: re-enable Git deployments for staging` (#48)

Net effect of the CI changes: one deploy path per environment. The Actions
workflow deploys **production only**; preview/staging is owned by the Vercel Git
integration. `vercel build --prebuilt` runs off `vercel pull`, which cannot
decrypt branch-scoped Preview `NEXT_PUBLIC_*` vars — it writes the literal
string `[SENSITIVE]`, which Next.js then inlines into the client bundle.

## Verification

- CI green on staging head (`b7eb913`).
- Staging live at `watch-staging.sideby.me`, serving the current head; client bundle inlines the real `https://sync-staging.sideby.me`, zero `[SENSITIVE]` occurrences.
- Current production bundle verified clean on the same prebuilt path (real `https://sync.sideby.me`), so promoting does not regress prod env inlining.
- `vercel.json` keeps `main: false`, so the Git integration will not double-deploy production alongside the Actions job.

The only commits on `main` and not on `staging` are the two prior promote merge commits — no unique content, so this is a clean fast-forward of content.